### PR TITLE
Fix CategoryHierarchy modal

### DIFF
--- a/src/models/CategoryHierarchy.js
+++ b/src/models/CategoryHierarchy.js
@@ -15,12 +15,48 @@
  *
  */
 
+import ApiClient from '../ApiClient'
+
 /**
 * The CategoryHierarchy model module.
 * @module models/CategoryHierarchy
 * @version v2
 */
 export default class CategoryHierarchy {
+    /**
+    * Constructs a new <code>CategoryHierarchy</code>.
+    * @alias module:models/CategoryHierarchy
+    * @class
+    */
+
+    constructor() {
+        /**
+    *
+    * @member {Array.<module:models/CategoryHierarchy>} subcategories
+    */
+        this.subcategories = undefined
+        /**
+    *
+    * @member {String} id
+    */
+        this.id = undefined
+        /**
+    *
+    * @member {String} lastModified
+    */
+        this.lastModified = undefined
+        /**
+    *
+    * @member {String} name
+    */
+        this.name = undefined
+        /**
+    *
+    * @member {String} url
+    */
+        this.url = undefined
+    }
+
     /**
     * Constructs a <code>CategoryHierarchy</code> from a plain JavaScript
     * object, optionally creating a new instance. Copies all relevant properties
@@ -31,12 +67,27 @@ export default class CategoryHierarchy {
     * @param {module:models/CategoryHierarchy} obj Optional instance to
     * populate.
     * @return {module:models/CategoryHierarchy} The populated
-    * <code>CategoryHierarchy</code> instance.
+    * <code>CatalogVersion</code> instance.
     */
     static constructFromObject(data, obj) {
         if (data) {
             obj = obj || new CategoryHierarchy()
 
+            if (data.hasOwnProperty('subcategories')) {
+                obj.subcategories = ApiClient.convertToType(data.subcategories, [CategoryHierarchy])
+            }
+            if (data.hasOwnProperty('id')) {
+                obj.id = ApiClient.convertToType(data.id, 'String')
+            }
+            if (data.hasOwnProperty('lastModified')) {
+                obj.lastModified = ApiClient.convertToType(data.lastModified, 'String')
+            }
+            if (data.hasOwnProperty('name')) {
+                obj.name = ApiClient.convertToType(data.name, 'String')
+            }
+            if (data.hasOwnProperty('url')) {
+                obj.url = ApiClient.convertToType(data.url, 'String')
+            }
         }
         return obj
     }

--- a/src/models/CategoryHierarchy.js
+++ b/src/models/CategoryHierarchy.js
@@ -67,7 +67,7 @@ export default class CategoryHierarchy {
     * @param {module:models/CategoryHierarchy} obj Optional instance to
     * populate.
     * @return {module:models/CategoryHierarchy} The populated
-    * <code>CatalogVersion</code> instance.
+    * <code>CategoryHierarchy</code> instance.
     */
     static constructFromObject(data, obj) {
         if (data) {

--- a/test/config.js
+++ b/test/config.js
@@ -29,7 +29,7 @@ const testWrapper = (occ) => {
     occ.currencies = occ.CurrencyOCC.constructFromObject({
         isocode: 'GBP',
         name: 'Pound',
-        active: false,
+        active: true,
         symbol: '£'
     })
     occ.deliveryCountries = [{


### PR DESCRIPTION
The swagger.json created by APImatic didn't include the properties for CategoryHierarchy modal. This resulted in a wrongly generated modal.

### Note
I have attempt to re-generate the client. However, there will still be manual steps to ensure the clients are generated properly according to readme. For example,
- camel case is property translated
- modals that refers to itself are generated properly