### PR TITLE
OrderEntryOCC model property name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## To be released
 - Fix OrderEntryOCC model [#9] (https://github.com/mobify/hybris-occ-client/pull/9)
 
-## v.0.1.3 (June 21, 2018)
+## v0.1.3 (June 21, 2018)
 - Fix superagent `attachCookies` and `saveCookies` usage
 
 ## v0.1.2 (May 18, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## To be released
+- Fix OrderEntryOCC model [#9] (https://github.com/mobify/hybris-occ-client/pull/9)
+
+## v.0.1.3 (June 21, 2018)
 - Fix superagent `attachCookies` and `saveCookies` usage
 
-## v0.1.2 (May 18, 20178)
-- Fix CategoryHierarchy modal [#5](https://github.com/mobify/hybris-occ-client/pull/5)
+## v0.1.2 (May 18, 2018)
+- Fix CategoryHierarchy model [#5](https://github.com/mobify/hybris-occ-client/pull/5)
 
 ## v0.1.1 (November 3, 2017)
 - Authentication update [#4](https://github.com/mobify/hybris-api-js-client/pull/4)

--- a/docs/models_OrderEntryOCC.js.html
+++ b/docs/models_OrderEntryOCC.js.html
@@ -64,11 +64,11 @@ export default class OrderEntryOCC {
     *
     * @member {Number} quantity
     */
-        this.dquantity = undefined
+        this.quantity = undefined
         /**
     * @member {module:models/Product} product
     */
-        this.dproduct = undefined
+        this.product = undefined
         /**
     * @member {module:models/DeliveryPointOfService} deliveryPointOfService
     */

--- a/src/models/OrderEntryOCC.js
+++ b/src/models/OrderEntryOCC.js
@@ -36,11 +36,11 @@ export default class OrderEntryOCC {
     *
     * @member {Number} quantity
     */
-        this.dquantity = undefined
+        this.quantity = undefined
         /**
     * @member {module:models/Product} product
     */
-        this.dproduct = undefined
+        this.product = undefined
         /**
     * @member {module:models/DeliveryPointOfService} deliveryPointOfService
     */


### PR DESCRIPTION
model property names are not correct so the api responses that give back an OrderEntryOCC model always give back undefined for quantity and product.